### PR TITLE
Fix memory leak issue caused by reference cycle

### DIFF
--- a/core/src/chunk.rs
+++ b/core/src/chunk.rs
@@ -181,6 +181,11 @@ impl Chunk {
 
     next_chunk
   }
+
+  pub(crate) fn clear(&mut self) {
+    self.next = None;
+    self.prev = None;
+  }
 }
 
 impl ToString for Chunk {

--- a/core/src/magic_string.rs
+++ b/core/src/magic_string.rs
@@ -816,8 +816,10 @@ impl Drop for MagicString {
   fn drop(&mut self) {
     // explicitly clear Rc RefCell cyclic references by setting them to
     // None before dropping to avoid memory leak caused by reference cycles
-    self.first_chunk.borrow_mut().clear();
     self.last_chunk.borrow_mut().clear();
+    self.first_chunk.borrow_mut().clear();
     self.last_searched_chunk.borrow_mut().clear();
+    self.chunk_by_end.iter_mut().for_each(|v| v.1.borrow_mut().clear());
+    self.chunk_by_start.iter_mut().for_each(|v| v.1.borrow_mut().clear());
   }
 }

--- a/core/src/magic_string.rs
+++ b/core/src/magic_string.rs
@@ -811,3 +811,13 @@ impl ToString for MagicString {
     format!("{}{}", str, self.outro)
   }
 }
+
+impl Drop for MagicString {
+  fn drop(&mut self) {
+    // explicitly clear Rc RefCell cyclic references by setting them to
+    // None before dropping to avoid memory leak caused by reference cycles
+    self.first_chunk.borrow_mut().clear();
+    self.last_chunk.borrow_mut().clear();
+    self.last_searched_chunk.borrow_mut().clear();
+  }
+}

--- a/core/src/magic_string.rs
+++ b/core/src/magic_string.rs
@@ -819,7 +819,13 @@ impl Drop for MagicString {
     self.last_chunk.borrow_mut().clear();
     self.first_chunk.borrow_mut().clear();
     self.last_searched_chunk.borrow_mut().clear();
-    self.chunk_by_end.iter_mut().for_each(|v| v.1.borrow_mut().clear());
-    self.chunk_by_start.iter_mut().for_each(|v| v.1.borrow_mut().clear());
+    self
+      .chunk_by_end
+      .iter_mut()
+      .for_each(|v| v.1.borrow_mut().clear());
+    self
+      .chunk_by_start
+      .iter_mut()
+      .for_each(|v| v.1.borrow_mut().clear());
   }
 }


### PR DESCRIPTION
# Motivation
Atm there is memory leak issue, caused by cyclic references that `MagicString` and `Chunk` struct instances hold on to, to reproduce the memory leak issue we can just run the following code snippet and monitor the memory usage:

```rust
let text = "some text with few lines"
loop {
      let mut generator = MagicString::new(text);
      generator.prepend("some other text");
      generator
          .overwrite(
              6,
              7,
              "some overwrite text",
              OverwriteOptions::default(),
          );
      let res = generator.to_string();
      println!("{}", res);
      std::thread::sleep(std::time::Duration::from_millis(50));
}
```
Memory leak comes mostly from `split()` method of `Chunk` where a reference cycle gets created at very last couple lines of the method (at least as far as I've been able to detect) which causes instances of `MagicString` to not completely free up the memory after they go out of scope.

![memory-leak](https://github.com/user-attachments/assets/22a187d5-8f0c-4ece-ba95-5719d0e211d4)


# Proposed Solution
To fix and avoid memory leak issue we simply need to drop all the cyclic references that have been created during `MagicString` method calls when an instance of `MagicString` is going out of scope, so we add a new private method for `Chunk` to set its `Option<Rc<RefCell>>` to `None` which ensures that all cyclic reference go out of scope explicitly:
```rust
pub(crate) fn clear(&mut self) {
  self.next = None;
  self.prev = None;
}
```
next we just implement `Drop` trait for `MagicString` to call `clear()` for its `Rc<RefCell<Chunk>>` properties:
```rust
impl Drop for MagicString {
  fn drop(&mut self) {
    self.first_chunk.borrow_mut().clear();
    self.last_chunk.borrow_mut().clear();
    self.last_searched_chunk.borrow_mut().clear();
    self.chunk_by_end.iter_mut().for_each(|v| v.1.borrow_mut().clear());
    self.chunk_by_start.iter_mut().for_each(|v| v.1.borrow_mut().clear());
  }
}
```
this ensures that any cyclic reference that has been created during method calls and are persisting even after an instance of `MagicString` goes out of scope, gets dropped explicitly before dropping the whole `MagicString` instance.
To check if the fix works, we can just run the snippet above once again and monitor the memory usage.

PS: There are probably other approaches to address and fix this issue, but I found this approach to be very minimal, and it doesn't touch and change any other parts of the code and logic while still guaranteeing no memory leak, as the logic of this lib has many recursive components and changing it might possibly introduce unintended bugs.